### PR TITLE
fix: reduce time for resolve

### DIFF
--- a/actions/humanize-text.ts
+++ b/actions/humanize-text.ts
@@ -45,7 +45,7 @@ export const humanizeTextForm = actionClient
 
       if (result.status === "queued" && result.id) {
         const id = result.id;
-        await new Promise((resolve) => setTimeout(resolve, 5000));
+        await new Promise((resolve) => setTimeout(resolve, 3000));
         // Retry fetching the result recursively
         const resendData = await fetch(`https://api.undetectable.ai/document`, {
           method: "POST",


### PR DESCRIPTION
Using a Vercel hobby plan and api routes can only be processed for 5 seconds:
https://stackoverflow.com/questions/68771480/nextjs-vercel-504-error-function-invocation-timeout